### PR TITLE
Bart/rename db dcatd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,24 @@ somewhat filled database
     done
 
 
+Load production data
+--------------------
+
+If you need to load production data  in development you can do the following commands
+The first two commands should not be required if database backups would correctly
+create the dcatd_latest.gz link. However this is currently not the case. That is
+why we need to copy manually with :
+
+    scp admin.datapunt.amsterdam.nl:/mnt/backup_postgres/dcatd_2018-09-03.gz /tmp/
+    docker cp  /tmp/dcatd_2018-09-03.gz  81adf880164c:/tmp/dcatd_latest.gz
+
+Here 81adf880164c is the docker container. 
+
+Then we can load it in Postgres with :
+
+    docker-compose exec database update-db.sh dcatd <yourname>
+
+
 Update documentation
 --------------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,15 @@ version: "3.0"
 services:
 
   database:
-    image: postgres:10
+    image: amsterdam/postgres
     ports:
       - "5433:5432"
     environment:
-      POSTGRES_DB: datacatalog
-      POSTGRES_USER: datacatalog
-      POSTGRES_PASSWORD: datacatalog
+      POSTGRES_DB: dcatd
+      POSTGRES_USER: dcatd
+      POSTGRES_PASSWORD: dcatd
+    volumes:
+        - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
 
   example:
     build:
@@ -20,9 +22,9 @@ services:
     ports:
       - "8001:8000"
     environment:
-      DB_DATABASE: datacatalog
-      DB_USER: datacatalog
-      DB_PASSWORD: datacatalog
+      DB_DATABASE: dcatd
+      DB_USER: dcatd
+      DB_PASSWORD: dcatd
       DB_HOST: database
       DB_PORT: 5432
       BASEURL: "http://localhost:8001/"
@@ -37,9 +39,9 @@ services:
     depends_on:
       - database
     environment:
-      DB_DATABASE: datacatalog
-      DB_USER: datacatalog
-      DB_PASSWORD: datacatalog
+      DB_DATABASE: dcatd
+      DB_USER: dcatd
+      DB_PASSWORD: dcatd
       DB_HOST: database
       DB_PORT: 5432
       SWIFT_PASSWORD: insecure

--- a/examples/running/config.yml
+++ b/examples/running/config.yml
@@ -6,11 +6,11 @@ plugins:
 primarySchema: dcat-ap-ams
 
 storage_postgres:
-  name: ${DB_DATABASE:-datacatalog}
+  name: ${DB_DATABASE:-dcatd}
   host: ${DB_HOST:-localhost}
-  pass: ${DB_PASS:-datacatalog}
+  pass: ${DB_PASS:-dcatd}
   port: ${DB_PORT:-5433}
-  user: ${DB_USER:-datacatalog}
+  user: ${DB_USER:-dcatd}
 
 storage_swift:
   user: ${SWIFT_USER:-catalogus}

--- a/src/datacatalog/plugins/postgres/__init__.py
+++ b/src/datacatalog/plugins/postgres/__init__.py
@@ -509,7 +509,7 @@ def _to_pg_lang(iso_639_1_code: str) -> str:
 def _to_pg_json_query(q: str) -> str:
     #   escape single quote (lexeme-demarcator in pg fulltext search) in words
     words = [t.replace("'", "[\\']") for  t in q.split()]
-    return ' | '.join("{}:*".format(w) for w in words)
+    return ' & '.join("{}:*".format(w) for w in words)
 
 
 def _etag_from_str(s: str) -> str:

--- a/tests/datacatalog/integration_config.yml
+++ b/tests/datacatalog/integration_config.yml
@@ -6,11 +6,11 @@ plugins:
 primarySchema: dcat-ap-ams
 
 storage_postgres:
-  name: ${DB_DATABASE:-datacatalog}
+  name: ${DB_DATABASE:-dcatd}
   host: ${DB_HOST:-localhost}
-  pass: ${DB_PASS:-datacatalog}
+  pass: ${DB_PASS:-dcatd}
   port: ${DB_PORT:-5433}
-  user: ${DB_USER:-datacatalog}
+  user: ${DB_USER:-dcatd}
 
 storage_swift:
   user: ${SWIFT_USER:-catalogus}

--- a/tests/datacatalog/plugins/test_postgres.py
+++ b/tests/datacatalog/plugins/test_postgres.py
@@ -226,6 +226,6 @@ def test_storage_delete(event_loop, corpus, app):
 
 
 def test_to_pg_json_query():
-    assert postgres_plugin._to_pg_json_query("Veer 1") == "Veer:* | 1:*"
+    assert postgres_plugin._to_pg_json_query("Veer 1") == "Veer:* & 1:*"
     assert postgres_plugin._to_pg_json_query("'s") == "[\\']s:*"
-    assert postgres_plugin._to_pg_json_query("'s-Gravelandse Veer 1") == "[\\']s-Gravelandse:* | Veer:* | 1:*"
+    assert postgres_plugin._to_pg_json_query("'s-Gravelandse Veer 1") == "[\\']s-Gravelandse:* & Veer:* & 1:*"

--- a/tests/datacatalog/plugins/test_postgres_config.yml
+++ b/tests/datacatalog/plugins/test_postgres_config.yml
@@ -1,9 +1,9 @@
 storage_postgres:
-  name: ${DB_DATABASE:-datacatalog}
+  name: ${DB_DATABASE:-dcatd}
   host: ${DB_HOST:-localhost}
-  pass: ${DB_PASS:-datacatalog}
+  pass: ${DB_PASS:-dcatd}
   port: ${DB_PORT:-5433}
-  user: ${DB_USER:-datacatalog}
+  user: ${DB_USER:-dcatd}
 
 
 


### PR DESCRIPTION
Het belangrijkste is de verandering van een OR in een AND search voor meerdere termen .

Daarnaast heb ik de database hermoemd naar dcatd en als image amsterdam/postgres om gemakkelijk de database uit productie te kunnen kopieren.