### PR TITLE
Bart/dp 5980

### DIFF
--- a/src/datacatalog/plugin_interfaces.py
+++ b/src/datacatalog/plugin_interfaces.py
@@ -187,7 +187,7 @@ def storage_id() -> str:
 # noinspection PyUnusedLocal
 @hookspec.first_only.required
 def search_search(
-    app, q: str, sortpath: T.List[str],
+    app, q: str, sort_field_get:T.Callable[[dict], str],
     result_info: T.MutableMapping,
     facets: T.Optional[T.Iterable[str]]=None,
     limit: T.Optional[int]=None, offset: T.Optional[int]=0,
@@ -206,7 +206,7 @@ def search_search(
 
     :param app: global dictionary
     :param q: the query
-    :param sortproperty: the property to sort by. Must be a top-level object property.
+    :param sort_field_get: function to get propererty to sort by.
     :param result_info: mapping in which all encountered facets in the result set are
         put
     :param facets: a list of facets to return and count

--- a/tests/datacatalog/plugins/test_postgres.py
+++ b/tests/datacatalog/plugins/test_postgres.py
@@ -170,13 +170,15 @@ def test_storage_extract(event_loop, corpus, app):
     empty = event_loop.run_until_complete(retrieve_nothing())
     assert len(empty) == 0
 
+def get_id_sort_field(doc:dict)->str:
+    return doc['@id'] if '@id' in doc else ''
 
 def test_search_search(event_loop, corpus, app):
     # search on query
     async def search(record):
         q = record['searchable_text']
         return [r async for r in postgres_plugin.search_search(
-            app=app, q=q, sortpath=['@id'], result_info={}, limit=1,
+            app=app, q=q, sort_field_get=get_id_sort_field, result_info={}, limit=1,
             filters=None, iso_639_1_code=record['iso_639_1_code'])]
 
     for corpus_id, corpus_doc in corpus.items():
@@ -188,7 +190,7 @@ def test_search_search(event_loop, corpus, app):
     async def search(record):
         filters = {'/properties/id': {'eq': record['doc']['id']}}
         return [r async for r in postgres_plugin.search_search(
-            app=app, q='', sortpath=['@id'], result_info={},
+            app=app, q='', sort_field_get=get_id_sort_field, result_info={},
             limit=1, filters=filters,
             iso_639_1_code=record['iso_639_1_code'])]
 
@@ -203,7 +205,7 @@ def test_search_search(event_loop, corpus, app):
         filters = {'/properties/keywords/items': {'eq': 'foo'}}
         result_info = {}
         return [r async for r in postgres_plugin.search_search(
-            app=app, q='', sortpath=['@id'], result_info=result_info,
+            app=app, q='', sort_field_get=get_id_sort_field, result_info=result_info,
             facets=['/properties/keywords/items'],
             limit=1, filters=filters,
             iso_639_1_code='nl')], result_info


### PR DESCRIPTION
https://datapunt.atlassian.net/browse/DP-5980

Zolang er nog niet teveel datasets zijn kan het sorteren zo worden meegenomen bij het inventariseren van de facetten . 

Een andere oplossing is het toevoegen van een sorteer datum in de dataset tabel. De wordt dan aangepast  bij het wijzigen van de dataset. Dan kan het sorteren ook weer plaatsvinden in Postgres   