### PR TITLE
allow optional authorization

### DIFF
--- a/src/datacatalog/authorization.py
+++ b/src/datacatalog/authorization.py
@@ -108,8 +108,10 @@ async def middleware(app, handler):
 
 
 async def _enforce_one_of(request: web.Request,
-                          security_requirements: T.List[T.Dict[
-                              str, T.Optional[T.Iterable]]
+                          security_requirements: T.List[
+                              T.Optional[T.Dict[
+                                str, T.Optional[T.Iterable]
+                              ]]
                           ]):
     for security_requirement in security_requirements:
         if await _enforce_all_of(request, security_requirement):
@@ -118,9 +120,11 @@ async def _enforce_one_of(request: web.Request,
 
 
 async def _enforce_all_of(request: web.Request,
-                          security_requirements: T.Dict[
+                          security_requirements: T.Optional[T.Dict[
                               str, T.Optional[T.Iterable]
-                          ]) -> bool:
+                          ]]) -> bool:
+    if security_requirements is None:
+        return True
     openapi = request.app['openapi']
     security_definitions = openapi['components']['securitySchemes']
     all_authz_info = await _extract_authz_info(request, security_definitions)


### PR DESCRIPTION
Hoi Bart et al.,

Ik vond nog een heel oude change ergens in mijn history van dcatd. Het doel was om authenticatie optioneel te maken, door het volgende in de swagger file te zetten:

```yaml
  /datasets/{id}:
    get:
      description: Get the dataset identified by id.
      security:
      - OAuth2:
        - CAT/R
      - null
```

Ik zie dat dat nu ook al gebeurt in dcatd, maar dan op deze manier:

```yaml
  /datasets/{id}:
    get:
      description: Get the dataset identified by id.
      security:
      - OAuth2:
        - CAT/R
      - {}
```

Ik weet niet of één van deze twee manieren ueberhaupt volgens de standaard is. Ik denk het niet eigenlijk. Maar op zich vind ik het toestaan van een `null` value wel een goed idee, dus ik heb het alsnog gepushed.